### PR TITLE
Implementasjon av søk2 mot helsepersonellregister

### DIFF
--- a/src/main/kotlin/no/nav/syfo/helsepersonell/BehandlerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/helsepersonell/BehandlerApi.kt
@@ -1,11 +1,12 @@
 package no.nav.syfo.helsepersonell
 
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.call
 import io.ktor.server.request.header
+import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import no.nav.syfo.logger
 
 fun Route.registerBehandlerApi(helsepersonellService: HelsepersonellService) {
@@ -58,6 +59,19 @@ fun Route.registerBehandlerApi(helsepersonellService: HelsepersonellService) {
                     }
                 }
             }
+        }
+    }
+
+    post("/behandlere") {
+        val soekeparametre = call.receive(Soekeparametre::class)
+
+        try {
+            call.respond(helsepersonellService.soekBehandlere(soekeparametre))
+        } catch (e: Exception) {
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                e.message ?: "Kunne ikke finne helsepersonell.",
+            )
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/helsepersonell/Behandlereresultat.kt
+++ b/src/main/kotlin/no/nav/syfo/helsepersonell/Behandlereresultat.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.helsepersonell
+
+data class Behandlereresultat(
+    val behandlere: List<Behandler>,
+)

--- a/src/main/kotlin/no/nav/syfo/helsepersonell/Soekeparametre.kt
+++ b/src/main/kotlin/no/nav/syfo/helsepersonell/Soekeparametre.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.helsepersonell
+
+data class Soekeparametre(
+    val fornavn: String? = null,
+    val etternavn: String? = null,
+    val mellomnavn: String? = null,
+    val hprNummer: String? = null,
+)

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -120,6 +120,32 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/Behandler"
+  /api/v2/behandlere:
+    post:
+      description: "Finn alle behandlere med kriterie. Søker på fornavn, mellomnavn, etternavn og HPR-nummer dersom kriterie er numerisk"
+      requestBody:
+        description: Søkekriterie
+        required: true
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/Soekeparametre"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Behandlereresultat"
+        "400":
+          description: "Bad Request"
+          content:
+            '*/*':
+              schema:
+                type: "string"
+              examples:
+                Example#1:
+                  value: "Søkekriterie er tom string"
   /api/v2/fastlegeinformasjon:
     get:
       description: ""
@@ -255,6 +281,12 @@ components:
           type: "string"
       required:
       - "godkjenninger"
+    Behandlereresultat:
+      type: "object"
+      properties:
+        behandlere:
+          type: "array"
+          items: "#/components/schema/Behandler"
     Person:
       type: "object"
       properties:
@@ -264,3 +296,14 @@ components:
           type: "string"
       required:
       - "navn"
+    Soekeparametre:
+      type: "object"
+      properties:
+        fornavn:
+          type: "string"
+        etternavn:
+          type: "string"
+        mellomnavn:
+          type: "string"
+        hprNummer:
+          type: "string"


### PR DESCRIPTION
- La til kode for å søke etter helsepersonell med fornavn, mellomnavn, etternavn og/eller hprNummer.
- La til post endepunkt for å søke
- La til modell for å sende søkeparametre og resultat
- La til tester